### PR TITLE
fix kernel version problem about function blk_account_io_completion. 

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1602,7 +1602,7 @@ Example:
 b = BPF(text="""
 BPF_HISTOGRAM(dist);
 
-int kprobe__blk_account_io_completion(struct pt_regs *ctx, struct request *req)
+int kprobe__blk_account_io_done(struct pt_regs *ctx, struct request *req)
 {
 	dist.increment(bpf_log2l(req->__data_len / 1024));
 	return 0;
@@ -1653,7 +1653,7 @@ Example:
 b = BPF(text="""
 BPF_HISTOGRAM(dist);
 
-int kprobe__blk_account_io_completion(struct pt_regs *ctx, struct request *req)
+int kprobe__blk_account_io_done(struct pt_regs *ctx, struct request *req)
 {
 	dist.increment(req->__data_len / 1024);
 	return 0;

--- a/docs/tutorial_bcc_python_developer.md
+++ b/docs/tutorial_bcc_python_developer.md
@@ -220,7 +220,7 @@ void trace_completion(struct pt_regs *ctx, struct request *req) {
 
 b.attach_kprobe(event="blk_start_request", fn_name="trace_start")
 b.attach_kprobe(event="blk_mq_start_request", fn_name="trace_start")
-b.attach_kprobe(event="blk_account_io_completion", fn_name="trace_completion")
+b.attach_kprobe(event="blk_account_io_done", fn_name="trace_completion")
 [...]
 ```
 
@@ -351,7 +351,7 @@ b = BPF(text="""
 
 BPF_HISTOGRAM(dist);
 
-int kprobe__blk_account_io_completion(struct pt_regs *ctx, struct request *req)
+int kprobe__blk_account_io_done(struct pt_regs *ctx, struct request *req)
 {
 	dist.increment(bpf_log2l(req->__data_len / 1024));
 	return 0;
@@ -374,7 +374,7 @@ b["dist"].print_log2_hist("kbytes")
 A recap from earlier lessons:
 
 - ```kprobe__```: This prefix means the rest will be treated as a kernel function name that will be instrumented using kprobe.
-- ```struct pt_regs *ctx, struct request *req```: Arguments to kprobe. The ```ctx``` is registers and BPF context, the ```req``` is the first argument to the instrumented function: ```blk_account_io_completion()```.
+- ```struct pt_regs *ctx, struct request *req```: Arguments to kprobe. The ```ctx``` is registers and BPF context, the ```req``` is the first argument to the instrumented function: ```blk_account_io_done()```.
 - ```req->__data_len```: Dereferencing that member.
 
 New things to learn:

--- a/examples/lua/kprobe-latency.lua
+++ b/examples/lua/kprobe-latency.lua
@@ -30,7 +30,7 @@ local lat_map = bpf.map('array', bins)
 local trace_start = bpf.kprobe('myprobe:blk_start_request', function (ptregs)
 	map[ptregs.parm1] = time()
 end, false, -1, 0)
-local trace_end = bpf.kprobe('myprobe2:blk_account_io_completion', function (ptregs)
+local trace_end = bpf.kprobe('myprobe2:blk_account_io_done', function (ptregs)
 	-- The lines below are computing index
 	-- using log10(x)*10 = log2(x)*10/log2(10) = log2(x)*3
 	-- index = 29 ~ 1 usec

--- a/examples/tracing/bitehist.py
+++ b/examples/tracing/bitehist.py
@@ -25,7 +25,7 @@ b = BPF(text="""
 BPF_HISTOGRAM(dist);
 BPF_HISTOGRAM(dist_linear);
 
-int kprobe_blk_account_io_done(struct pt_regs *ctx, struct request *req)
+int kprobe__blk_account_io_done(struct pt_regs *ctx, struct request *req)
 {
 	dist.increment(bpf_log2l(req->__data_len / 1024));
 	dist_linear.increment(req->__data_len / 1024);

--- a/examples/tracing/bitehist.py
+++ b/examples/tracing/bitehist.py
@@ -16,22 +16,31 @@
 from __future__ import print_function
 from bcc import BPF
 from time import sleep
+import os
+
+# check "blk_account_io_completion" against /proc/kallsyms
+string = os.popen('cat /proc/kallsyms | ' + 
+			'grep "blk_account_io_completion"'
+			).read()
+if len(string.strip()) > 0: 
+    event = "blk_account_io_completion"
+else: 
+    event = "blk_account_io_done"
 
 # load BPF program
 b = BPF(text="""
 #include <uapi/linux/ptrace.h>
 #include <linux/blkdev.h>
-
 BPF_HISTOGRAM(dist);
 BPF_HISTOGRAM(dist_linear);
-
-int kprobe__blk_account_io_completion(struct pt_regs *ctx, struct request *req)
+int kprobe_blk_account_io_completion(struct pt_regs *ctx, struct request *req)
 {
 	dist.increment(bpf_log2l(req->__data_len / 1024));
 	dist_linear.increment(req->__data_len / 1024);
 	return 0;
 }
 """)
+b.attach_kprobe(event=event, fn_name='kprobe_blk_account_io_completion')
 
 # header
 print("Tracing... Hit Ctrl-C to end.")

--- a/examples/tracing/disksnoop.py
+++ b/examples/tracing/disksnoop.py
@@ -46,7 +46,7 @@ void trace_completion(struct pt_regs *ctx, struct request *req) {
 if BPF.get_kprobe_functions(b'blk_start_request'):
         b.attach_kprobe(event="blk_start_request", fn_name="trace_start")
 b.attach_kprobe(event="blk_mq_start_request", fn_name="trace_start")
-b.attach_kprobe(event="blk_account_io_completion", fn_name="trace_completion")
+b.attach_kprobe(event="blk_account_io_done", fn_name="trace_completion")
 
 # header
 print("%-18s %-2s %-7s %8s" % ("TIME(s)", "T", "BYTES", "LAT(ms)"))

--- a/tools/biosnoop.lua
+++ b/tools/biosnoop.lua
@@ -126,7 +126,7 @@ return function(BPF, utils)
   bpf:attach_kprobe{event="blk_account_io_start", fn_name="trace_pid_start"}
   bpf:attach_kprobe{event="blk_start_request", fn_name="trace_req_start"}
   bpf:attach_kprobe{event="blk_mq_start_request", fn_name="trace_req_start"}
-  bpf:attach_kprobe{event="blk_account_io_completion",
+  bpf:attach_kprobe{event="blk_account_io_done",
       fn_name="trace_req_completion"}
 
   print("%-14s %-14s %-6s %-7s %-2s %-9s %-7s %7s" % {"TIME(s)", "COMM", "PID",

--- a/tools/biosnoop.py
+++ b/tools/biosnoop.py
@@ -160,7 +160,7 @@ b.attach_kprobe(event="blk_account_io_start", fn_name="trace_pid_start")
 if BPF.get_kprobe_functions(b'blk_start_request'):
     b.attach_kprobe(event="blk_start_request", fn_name="trace_req_start")
 b.attach_kprobe(event="blk_mq_start_request", fn_name="trace_req_start")
-b.attach_kprobe(event="blk_account_io_completion",
+b.attach_kprobe(event="blk_account_io_done",
     fn_name="trace_req_completion")
 
 # header

--- a/tools/biotop.py
+++ b/tools/biotop.py
@@ -178,7 +178,7 @@ b.attach_kprobe(event="blk_account_io_start", fn_name="trace_pid_start")
 if BPF.get_kprobe_functions(b'blk_start_request'):
     b.attach_kprobe(event="blk_start_request", fn_name="trace_req_start")
 b.attach_kprobe(event="blk_mq_start_request", fn_name="trace_req_start")
-b.attach_kprobe(event="blk_account_io_completion",
+b.attach_kprobe(event="blk_account_io_done",
     fn_name="trace_req_completion")
 
 print('Tracing... Output every %d secs. Hit Ctrl-C to end' % interval)

--- a/tools/old/biosnoop.py
+++ b/tools/old/biosnoop.py
@@ -98,7 +98,7 @@ int trace_req_completion(struct pt_regs *ctx, struct request *req)
 b.attach_kprobe(event="blk_account_io_start", fn_name="trace_pid_start")
 b.attach_kprobe(event="blk_start_request", fn_name="trace_req_start")
 b.attach_kprobe(event="blk_mq_start_request", fn_name="trace_req_start")
-b.attach_kprobe(event="blk_account_io_completion",
+b.attach_kprobe(event="blk_account_io_done",
     fn_name="trace_req_completion")
 
 # header


### PR DESCRIPTION
The kernel function "blk_account_io_completion" is not available as attach point for Kprobe anymore, as of kernel version 5.8.0. Therefore, after discussions, we decided to use function "blk_account_io_done" instead in everywhere. 