### PR TITLE
Script that traces queuing time and service time

### DIFF
--- a/tools/blkrqhist.py
+++ b/tools/blkrqhist.py
@@ -15,7 +15,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 #
 # 08-Jun-2020   Haoning Chen   Created this. 
-# 03-Aug-2020	Haoning Chen   Added raw tracepoint implementation. 
+# 03-Aug-2020   Haoning Chen   Added raw tracepoint implementation. 
 
 from __future__ import print_function
 from time import sleep
@@ -99,7 +99,6 @@ RAW_TRACEPOINT_PROBE(block_rq_complete) {
 
 if len(sys.argv) > 1 and sys.argv[1] == 'T': 	# use tracepoint 
 	bpf = BPF(text=bpf_text_head+bpf_text_tracepoint) 
-	bpf.attach_raw_tracepoint(tp="block_rq_complete", fn_name="trace_rq_complete") 
 
 else:		# default: use kprobe
 	bpf = BPF(text=bpf_text_head+bpf_text_kprobe) 

--- a/tools/blkrqhist.py
+++ b/tools/blkrqhist.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 # 
-# blkrqhist.py      Instrument two time periods of block layer's I/O requests: queuing time and  
+# blkrqhist.py		Instrument two time periods of block layer's I/O requests: queuing time and  
 #					service time. One histograme is generated for each. Here queuing time is defined 
 #					as the time of an I/O request being queued in kernel, and service time is the 
 #					duration the I/O request being handled by device drivers, up to its completion. 

--- a/tools/blkrqhist.py
+++ b/tools/blkrqhist.py
@@ -8,7 +8,7 @@
 # Copyright (c) Google LLC
 # Licensed under the Apache License, Version 2.0 (the "License")
 #
-# 08-Jun-2020   Haoning CHen   Created this.
+# 08-Jun-2020   Haoning Chen   Created this. 
 
 from __future__ import print_function
 from time import sleep

--- a/tools/blkrqhist.py
+++ b/tools/blkrqhist.py
@@ -1,0 +1,83 @@
+#!/usr/bin/python
+# 
+# blkrqhist.py      Instrument two time periods of block layer's I/O requests: queuing time and  
+#					service time. One histograme is generated for each. Here queuing time is defined 
+#					as the time of an I/O request being queued in kernel, and service time is the 
+#					duration the I/O request being handled by device drivers, up to its completion. 
+# 
+# Copyright (c) Google LLC
+# Licensed under the Apache License, Version 2.0 (the "License")
+#
+# 08-Jun-2020   Haoning CHen   Created this.
+
+from __future__ import print_function
+from time import sleep
+from bcc import BPF
+
+# BPF program
+bpf_text="""
+#include <uapi/linux/ptrace.h>
+#include <linux/blkdev.h>
+
+BPF_HASH(creation, struct request *);
+BPF_HASH(start, struct request *);
+BPF_HISTOGRAM(que_hist);
+BPF_HISTOGRAM(serv_hist);
+
+int trace_rq_creation(struct pt_regs *ctx, struct request *req) {
+    // stash creation timestamp by request ptr
+	u64 ts = bpf_ktime_get_ns();
+	creation.update(&req, &ts);
+
+	return 0;
+}
+
+int trace_rq_start(struct pt_regs *ctx, struct request *req) {
+	// stash start timestamp by request ptr
+	u64 ts = bpf_ktime_get_ns();
+	start.update(&req, &ts);
+
+	return 0;
+}
+
+int trace_rq_completion(struct pt_regs *ctx, struct request *req) {
+	u64 *create_tsp, *start_tsp, que_delta, serv_delta;
+	create_tsp = creation.lookup(&req);
+	start_tsp  = start.lookup(&req);
+	if (create_tsp != NULL && start_tsp != NULL) {
+		que_delta = *start_tsp - *create_tsp;
+		serv_delta = bpf_ktime_get_ns() - *start_tsp;
+
+		que_hist.increment(bpf_log2l(que_delta / 1000));
+		serv_hist.increment(bpf_log2l(serv_delta / 1000));
+
+		creation.delete(&req);
+		start.delete(&req);
+	}
+
+	return 0;
+}
+"""
+
+bpf = BPF(text=bpf_text)
+
+bpf.attach_kprobe(event="blk_account_io_start", fn_name="trace_rq_creation")
+if BPF.get_kprobe_functions(b'blk_start_request'):
+	bpf.attach_kprobe(event="blk_start_request", fn_name="trace_rq_start")
+bpf.attach_kprobe(event="blk_mq_start_request", fn_name="trace_rq_start")
+bpf.attach_kprobe(event="blk_account_io_done", fn_name="trace_rq_completion")
+
+
+# header
+print("Tracing I/O requests... Hit Ctrl-C to end.")
+
+# trace until keyboard interrupt
+try:
+	sleep(99999999)
+except KeyboardInterrupt:
+	print()
+
+# output
+bpf["que_hist"].print_log2_hist("Queuing time (us)")
+print(end="\n\n")
+bpf["serv_hist"].print_log2_hist("Service time (us)")

--- a/tools/blkrqhist.py
+++ b/tools/blkrqhist.py
@@ -1,21 +1,29 @@
 #!/usr/bin/python
 # 
 # blkrqhist.py		Instrument two time periods of block layer's I/O requests: queuing time and  
-#					service time. One histograme is generated for each. Here queuing time is defined 
-#					as the time of an I/O request being queued in kernel, and service time is the 
-#					duration the I/O request being handled by device drivers, up to its completion. 
+#			service time. One histograme is generated for each. Here queuing time is defined 
+#			as the time of an I/O request being queued in kernel, and service time is the 
+#			duration the I/O request being handled by device drivers, up to its completion. 
 # 
+# 
+# Usage: 
+# To run with Kprobe implementation (by default):	./blkrqhist.py
+# With Raw tracepoint implementation: 			./blkrqhist.py T 
+#
+#
 # Copyright (c) Google LLC
 # Licensed under the Apache License, Version 2.0 (the "License")
 #
 # 08-Jun-2020   Haoning Chen   Created this. 
+# 03-Aug-2020	Haoning Chen   Added raw tracepoint implementation. 
 
 from __future__ import print_function
 from time import sleep
-from bcc import BPF
+from bcc import BPF 
+import sys 
 
 # BPF program
-bpf_text="""
+bpf_text_head = """
 #include <uapi/linux/ptrace.h>
 #include <linux/blkdev.h>
 
@@ -24,23 +32,21 @@ BPF_HASH(start, struct request *);
 BPF_HISTOGRAM(que_hist);
 BPF_HISTOGRAM(serv_hist);
 
-int trace_rq_creation(struct pt_regs *ctx, struct request *req) {
-    // stash creation timestamp by request ptr
+static int rq_insert(struct request *req) {
+	// stash creation timestamp by request ptr
 	u64 ts = bpf_ktime_get_ns();
 	creation.update(&req, &ts);
-
 	return 0;
 }
 
-int trace_rq_start(struct pt_regs *ctx, struct request *req) {
+static int rq_issue(struct request *req) {
 	// stash start timestamp by request ptr
 	u64 ts = bpf_ktime_get_ns();
 	start.update(&req, &ts);
-
 	return 0;
 }
 
-int trace_rq_completion(struct pt_regs *ctx, struct request *req) {
+static int rq_complete(struct request *req) {
 	u64 *create_tsp, *start_tsp, que_delta, serv_delta;
 	create_tsp = creation.lookup(&req);
 	start_tsp  = start.lookup(&req);
@@ -54,18 +60,55 @@ int trace_rq_completion(struct pt_regs *ctx, struct request *req) {
 		creation.delete(&req);
 		start.delete(&req);
 	}
-
 	return 0;
+}
+
+"""
+
+bpf_text_kprobe = """
+int trace_rq_insert(struct pt_regs *ctx, struct request *req) {
+	return rq_insert(req);
+}
+
+int trace_rq_issue(struct pt_regs *ctx, struct request *req) {
+	return rq_issue(req);
+}
+
+int trace_rq_complete(struct pt_regs *ctx, struct request *req) {
+	return rq_complete(req);
 }
 """
 
-bpf = BPF(text=bpf_text)
+bpf_text_tracepoint = """ 
+RAW_TRACEPOINT_PROBE(block_rq_insert) {
+	// TP_PROTO(struct request_queue *q, struct request *rq) 
+	return rq_insert((struct request *) ctx->args[1]); 
+}
 
-bpf.attach_kprobe(event="blk_account_io_start", fn_name="trace_rq_creation")
-if BPF.get_kprobe_functions(b'blk_start_request'):
-	bpf.attach_kprobe(event="blk_start_request", fn_name="trace_rq_start")
-bpf.attach_kprobe(event="blk_mq_start_request", fn_name="trace_rq_start")
-bpf.attach_kprobe(event="blk_account_io_done", fn_name="trace_rq_completion")
+RAW_TRACEPOINT_PROBE(block_rq_issue) {
+	// TP_PROTO(struct request_queue *q, struct request *rq) 
+	return rq_issue((struct request *) ctx->args[1]); 
+}
+
+RAW_TRACEPOINT_PROBE(block_rq_complete) {
+	// TP_PROTO(struct request *rq, int error, unsigned int nr_bytes) 
+	return rq_complete((struct request *) ctx->args[0]); 
+}
+"""
+
+
+if len(sys.argv) > 1 and sys.argv[1] == 'T': 	# use tracepoint 
+	bpf = BPF(text=bpf_text_head+bpf_text_tracepoint) 
+	bpf.attach_raw_tracepoint(tp="block_rq_complete", fn_name="trace_rq_complete") 
+
+else:		# default: use kprobe
+	bpf = BPF(text=bpf_text_head+bpf_text_kprobe) 
+
+	bpf.attach_kprobe(event="blk_account_io_start", fn_name="trace_rq_insert")
+	if BPF.get_kprobe_functions(b'blk_start_request'):
+		bpf.attach_kprobe(event="blk_start_request", fn_name="trace_rq_issue")
+	bpf.attach_kprobe(event="blk_mq_start_request", fn_name="trace_rq_issue")
+	bpf.attach_kprobe(event="blk_account_io_done", fn_name="trace_rq_complete")
 
 
 # header
@@ -81,3 +124,4 @@ except KeyboardInterrupt:
 bpf["que_hist"].print_log2_hist("Queuing time (us)")
 print(end="\n\n")
 bpf["serv_hist"].print_log2_hist("Service time (us)")
+

--- a/tools/blkrqhist_example.txt
+++ b/tools/blkrqhist_example.txt
@@ -1,0 +1,52 @@
+Demonstrations of blkrqhist, the Linux eBPF/bcc version.
+
+This tool generates latency histograms for queuing time and service time of block layer
+I/O requests respectively. Here queuing time is the time of the request being queued in 
+kernel, and service time is the time it is processed by device drivers until completion.
+
+The tool can use either kprobe or raw tracepoint to implement the tracing. It uses kprobe 
+by default and can be switched to raw tracepoint via command line flag. 
+
+
+Usage:
+# ./blkrqhist.py       Generate histograms by kprobe tracing.
+# ./blkrqhist.py -T    Use raw tracepoint implementation instead. 
+
+
+Sample output:
+# ./blkrqhist.py
+Tracing I/O requests... Hit Ctrl-C to end.
+^C
+     Queuing time (us)   : count     distribution
+         0 -> 1          : 0        |                                        |
+         2 -> 3          : 39       |*                                       |
+         4 -> 7          : 11       |                                        |
+         8 -> 15         : 8        |                                        |
+        16 -> 31         : 4        |                                        |
+        32 -> 63         : 15       |                                        |
+        64 -> 127        : 5        |                                        |
+       128 -> 255        : 250      |*********                               |
+       256 -> 511        : 1026     |****************************************|
+       512 -> 1023       : 282      |**********                              |
+      1024 -> 2047       : 66       |**                                      |
+      2048 -> 4095       : 24       |                                        |
+      4096 -> 8191       : 20       |                                        |
+      8192 -> 16383      : 7        |                                        |
+
+
+     Service time (us)   : count     distribution
+         0 -> 1          : 0        |                                        |
+         2 -> 3          : 0        |                                        |
+         4 -> 7          : 0        |                                        |
+         8 -> 15         : 0        |                                        |
+        16 -> 31         : 0        |                                        |
+        32 -> 63         : 0        |                                        |
+        64 -> 127        : 0        |                                        |
+       128 -> 255        : 0        |                                        |
+       256 -> 511        : 0        |                                        |
+       512 -> 1023       : 1        |                                        |
+      1024 -> 2047       : 129      |******                                  |
+      2048 -> 4095       : 724      |*************************************   |
+      4096 -> 8191       : 782      |****************************************|
+      8192 -> 16383      : 117      |*****                                   |
+     16384 -> 32767      : 19       |                                        |


### PR DESCRIPTION
Just constructed the script "blkrqhist.py" that traces queueing time and service time, and generates histograms for each one. 